### PR TITLE
Remove unnecessary `image/avif` config from nginx docs

### DIFF
--- a/doc/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
+++ b/doc/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
@@ -24,9 +24,6 @@ The following configuration is used with the assumption that it is for developme
 ```nginx
 # mime types are already covered in nginx.conf
 #include mime.types;
-types {
-    image/avif avif;
-}
 
 upstream php-pimcore10 {
     server unix:/var/run/php/pimcore.sock;
@@ -201,9 +198,6 @@ The following configuration provides an approperiate base for a secure applicati
 ```nginx
 # mime types are already covered in nginx.conf
 #include mime.types;
-types {
-    image/avif avif;
-}
 
 upstream php-pimcore10 {
     server unix:/var/run/php/pimcore.sock;


### PR DESCRIPTION
Followup of pimcore/skeleton#164